### PR TITLE
#348 - Fix security issue where anybody could provide new feedback to any review

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -26,6 +26,10 @@ class FeedbacksController < ApplicationController
   # GET /feedbacks/new
   # GET /feedbacks/new.json
   def new
+    if @review.invitations.where(email: current_user.email).empty?
+      redirect_to root_path, notice: "You have not been invited to submit feedback for this review"
+      return
+    end
     @feedback = Feedback.new
     find_feedback_for(current_user) if @review.has_existing_feedbacks?
 

--- a/app/views/feedbacks/edit.html.erb
+++ b/app/views/feedbacks/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Feedback for <%= @review %></h1>
+<h1>Editing Feedback for <%= @feedback.review %></h1>
 
 <%= render :partial => 'form', :locals => {:additional => !@feedback.user_string.nil? } %>
 <div class="delete_padder">

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -13,7 +13,7 @@
   <%= link_to 'View Summary', summary_review_path(review) %> |
 <% end %>
 <% if can? :manage, review %>
-	<%= link_to 'New Feedback', new_review_feedback_path(review), :class => 'new_feedback_link' %> |
+	<!--<%= link_to 'New Feedback', new_review_feedback_path(review), :class => 'new_feedback_link' %> | -->
 <% end %>
 <% if can? :create_additional, Feedback %>
   <%= link_to 'Additional Feedback', additional_review_feedbacks_path(review) %> |

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -75,6 +75,7 @@ describe FeedbacksController do
     end
     it "loads the existing feedback if one exists for this user" do
       feedback = FactoryGirl.create(:feedback, :review => @review, :user => @user)
+      @review.invitations.create(:email => @user.email)
       get :new, {:review_id => @review.id}, valid_session
       assigns(:feedback).should eq(feedback)
       assigns(:user_name).should eq(@user.name)
@@ -90,6 +91,7 @@ describe FeedbacksController do
       end
       it "loads the existing feedback if one exists for this user" do
         feedback = FactoryGirl.create(:feedback, :review => @review, :user => @user)
+        @review.invitations.create(:email => @user.email)
         get :new, {:review_id => @review.id}, valid_session
         assigns(:feedback).should eq(feedback)
         assigns(:user_name).should eq(@user.name)

--- a/spec/requests/review_pages_spec.rb
+++ b/spec/requests/review_pages_spec.rb
@@ -284,10 +284,11 @@ describe "Review pages" do
         current_path.should == new_review_invitation_path(review)
       end
 
-      it "links to new feedback" do
-        click_link "New Feedback"
-        current_path.should == new_review_feedback_path(review)
-      end
+   #   it "links to new feedback" do
+   #     click_link "New Feedback"
+#  #     current_path.should == new_review_feedback_path(review)
+   #     current_path.should == root_path
+   #   end
 
       it "links to additional feedback" do
         click_link "Additional Feedback"


### PR DESCRIPTION
#348 - @bsmith3541 @ajablonski - Fix security and experience issues with adding new and editing existing feedback

-Fix 'New Feedback' link being reachable for uninvited users.
-Fix tests that failed from 'New Feedback' security fix; tentatively remove admin 'New Feedback' button
-Fix bug where wrong review heading was displayed on 'Edit Feedback' page
