### PR TITLE
#34 - Make New AC form persist fields, errors, and checkbox state

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,9 @@ class UsersController < ApplicationController
       end
 
     else
-      @user.build_associate_consultant
+      if @user.associate_consultant.nil?
+        @user.build_associate_consultant
+      end
       render 'new'
     end
   end

--- a/app/models/associate_consultant.rb
+++ b/app/models/associate_consultant.rb
@@ -24,4 +24,12 @@ class AssociateConsultant < ActiveRecord::Base
   def hasGraduated?
     !self.graduated.nil? && self.graduated
   end
+
+  def blank?
+    self.reviewing_group.blank? &&
+      self.coach.blank? &&
+      self.graduated.blank? &&
+      self.program_start_date.blank? &&
+      self.notes.blank?
+  end
 end

--- a/app/views/users/_admin_form.html.erb
+++ b/app/views/users/_admin_form.html.erb
@@ -34,14 +34,16 @@
     </div>
 
     <div class="field">
-      <% if @user.ac? %>
-        <%= check_box_tag 'isac', 'yes', true, disabled: true %> <%= f.label "Associate Consultant", class: "checkbox" %>
-      <% else %>
-        <%= check_box_tag 'isac' %> <%= f.label "Associate Consultant", class: "checkbox" %>
+      <%= check_box_tag 'isac',
+        '1', # value
+        !@user.associate_consultant.blank? || !@user.associate_consultant.errors.empty?, #checked
+        disabled: @user.ac? %>
+      <%= f.label "Associate Consultant", class: "checkbox" %>
+      <% unless @user.ac? %>
         <p class="help-text">Reviews will be created for new ACs if start date is not blank.</p>
       <% end %>
     </div>
-    
+
     <section class="nested-form-container">
       <%= f.fields_for :associate_consultant %>
     </section>


### PR DESCRIPTION
With @bsmith3541.

The AC form should be automatically checked and fields persisted when: there are errors OR any fields are filled in.
The AC form should appear when the form is checked when there are errors on the User portion of the form.
