### PR TITLE
#55 - Remove coach table from AC-Coach homepage

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -2,14 +2,9 @@
 
   <% if current_user.ac? && !current_user.associate_consultant.graduated %>
     <% upcoming_review = current_user.associate_consultant.upcoming_review %>
-    
+
     <h1>Your Upcoming <%= upcoming_review.review_type unless upcoming_review.nil? %> Review</h1>
     <%= render :partial => 'welcome/index_ac', :locals => { :upcoming_review => upcoming_review } %>
-
-    <% unless current_user.coachees.empty? %>
-      <%= render :partial => 'index_user' %>
-    <% end %>
-
   <% elsif current_user.admin? %>
     <h1>Watched Reviews</h1>
     <div class="new-review"><%= link_to 'New Review', new_review_path, :class => 'button' %></div>

--- a/spec/requests/home_page_spec.rb
+++ b/spec/requests/home_page_spec.rb
@@ -82,16 +82,6 @@ describe "Home page" do
         page.should_not have_selector("h1", text: @first_review.review_type.upcase)
       end
 
-      describe "who is also a coach" do
-        it "should contain a table of coachee reviews" do
-          coach_ac = FactoryGirl.create(:associate_consultant, user: FactoryGirl.create(:user))
-          @ac_with_many_reviews.coach = coach_ac.user
-          coach_ac.user.coachees << @ac_with_many_reviews
-          sign_in coach_ac.user
-          page.should have_selector("h1", text: "Watched Reviews")
-        end
-      end
-
       describe "who has graduated", js: true do
         before do
           graduated_ac = FactoryGirl.create(:associate_consultant,


### PR DESCRIPTION
with @bsmith3541 

ACs who are also coaches only see their own reviews on their homepage; coachee reviews are located on the "Coachee reviews" page (and on "My Reviews", until we allow filtering).
