### PR TITLE
Add Rubocop YML to override default Rubocop settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Style/StringLiterals:
+  EnforcedStyle: double_quotes


### PR DESCRIPTION
Specifically, standardize on the (hound-preferred) double quotes
