### PR TITLE
Some quick fixes around the site

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -79,7 +79,7 @@ jQuery (function () {
     $("#which-reviews").toggle();
   });
 
-  $('.sidenav a[href^="' + location.pathname + '"]').first().parent().addClass("active");
+  $('.sidenav a[href^="' + location.pathname + '"]').first().addClass("active");
 
   $("#add-email").on("click", function(){
     $.ajax({

--- a/app/assets/stylesheets/base/_badges.scss
+++ b/app/assets/stylesheets/base/_badges.scss
@@ -1,7 +1,7 @@
 $badge-background: lighten($brand-primary, 20%);
 $badge-dark-color: $dark-gray;
 $badge-error-color: $error-color;
-$badge-notice-color: $brand-complement;
+$badge-notice-color: darken($brand-primary, 13%);
 $badge-success-color: $success-color;
 $badge-font-color: white;
 $badge-font-size: $base-font-size * .75;

--- a/app/assets/stylesheets/components/_sidenav.css.scss
+++ b/app/assets/stylesheets/components/_sidenav.css.scss
@@ -30,21 +30,19 @@
   background-color: $brand-input-border;
 }
 
-.sidenav li:not(.header):not(.active):hover {
+.sidenav li:not(.header):hover {
   background-color: $brand-container-gray;
   cursor: pointer;
 }
 
-.sidenav li.active {
+.sidenav a.active > li {
   background-color: $brand-mint;
-
-  a {
-    color: white;
-  }
+  color: white;
 }
 
-.sidenav li.active:hover {
-  background-color: lighten($brand-mint, 5%);
+.sidenav a.active > li:hover {
+  background-color: lighten($brand-mint, 5%) !important;
+  cursor: default;
 }
 
 .excel-image {

--- a/app/views/invitations/new.html.erb
+++ b/app/views/invitations/new.html.erb
@@ -19,11 +19,15 @@
   <p class="help-text">Must have an '@thoughtworks.com' email address; separate multiple emails with ','</p>
   <%= text_field_tag :emails, nil, class: "long" %>
 </div>
-<div id="email_contents">
-    <p><%= label_tag :subject, "Subject:" %>
-  <%= text_field_tag :subject, "[ReviewSite] You've been asked to give feedback for #{@ac.user.name}"  %></p>
 
-    <p><%= label_tag :message, "Body:" %></p>
+
+<div id="email_contents">
+<div class="field">
+  <%= label_tag :subject, "Subject:" %>
+  <p>[ReviewSite] You've been asked to give feedback for <%= @ac.user.name %></p>
+</div>
+
+    <%= label_tag :message, "Body:" %>
     <% @default_body = <<-EOM
 You have been asked to provide feedback for #{@ac.user.name}. In order to access the site, please add the "Labs: TW Review Site" app in your Okta dashboard.
 Once you've added the app, please visit #{new_review_feedback_url(@review)} to add and submit your feedback.

--- a/app/views/reviews/_sidenav.html.erb
+++ b/app/views/reviews/_sidenav.html.erb
@@ -3,40 +3,59 @@
     <li class="header">Manage Review</li>
 
     <% if can? :read, review %>
-    <li><%= link_to "Track Feedback Progress", review %></li>
+      <%= link_to review do %>
+        <li>Track Feedback Progress</li>
+      <% end %>
     <% end %>
 
     <% if can? :summary, review %>
-    <li><%= link_to "Feedback Summary", summary_review_path(review) %></li>
+      <%= link_to summary_review_path(review) do %>
+        <li>Feedback Summary</li>
+      <% end %>
     <% end %>
 
     <% if can? :create, (review.invitations.build && review.invitations.pop) %>
-      <li><%= link_to "Ask for Feedback", new_review_invitation_path(review) %></li>
+      <%= link_to new_review_invitation_path(review) do %>
+        <li>Ask For Feedback</li>
+      <% end %>
     <% end %>
 
     <% if can? :create, (review.self_assessments.build && review.self_assessments.pop) %>
-      <% if review.self_assessments.count > 0 %>
-        <li><%= link_to "Update Self-Assessment", edit_review_self_assessment_path(review, review.self_assessments.first) %></li>
+      <% if review.self_assessments.count > 0 %>    
+        <%= link_to edit_review_self_assessment_path(review, review.self_assessments.first) do %>
+          <li>Update Self-Assessment</li>
+        <% end %>
       <% else %>
-        <li><%= link_to "Submit Self-Assessment", new_review_self_assessment_path(review) %></li>
+        <%= link_to new_review_self_assessment_path(review) do %>
+          <li>Submit Self-Assessment</li>
+        <% end %>
       <% end %>
     <% end %>
 
     <% if can? :create, (review.feedbacks.build && review.feedbacks.pop) %>
-      <li><%= link_to "Record External Feedback", additional_review_feedback_path(review) %></li>
+      <%= link_to additional_review_feedback_path(review) do %>
+        <li>Record External Feedback</li>
+      <% end %>
     <% end %>
 
-    <li>
-      <%= link_to url_for(:action => "summary", :controller => "reviews", :id => review, :format => "xlsx"), id: "export_to_excel" do %>
-          Export to <%= image_tag("excel_icon.gif", :class => "excel-image") %>
-      <% end %>
-    </li>
+    <%= link_to url_for(:action => "summary", :controller => "reviews", :id => review, :format => "xlsx"), id: "export_to_excel" do %>
+      <li>Export to <%= image_tag("excel_icon.gif", :class => "excel-image") %></li>
+    <% end %>
 
     <% if current_user.admin? %>
       <li class="header">Admin Panel</li>
-      <li><%= link_to "Email Review Info", send_email_review_path(@review), remote: true %></li>
-      <li><%= link_to "Edit Review Details", edit_review_path(@review), id: "review_edit" %></li>
-      <li><%= link_to "Delete Review", @review, method: :delete, data: { confirm: "Are you sure you want to delete this review? This will also delete all associated feedback." }, id: "review_destroy" %></li>
+      
+      <%= link_to send_email_review_path(@review), remote: true do %>
+        <li>Email Review Info to AC</li>
+      <% end %>
+
+      <%= link_to edit_review_path(@review), id: "review_edit" do %>
+        <li>Edit Review Details</li>
+      <% end %>
+
+      <%= link_to @review, method: :delete, data: { confirm: "Are you sure you want to delete this review? This will also delete all associated feedback." }, id: "review_destroy" do %>
+        <li>Delete Review</li>
+      <% end %>
 
   <% end %>
   </ul>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -25,7 +25,7 @@
 
   <div class="actions">
     <%= f.submit "#{button_title}", :id => "user-form-submit" %>
-    <%= link_to "Cancel", users_path, :class => "diet button" %>
+    <%= link_to "Cancel", cancel_link, :class => "diet button" %>
   </div>
 
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,10 +1,14 @@
 <% if current_user == @user %>
   <h1>Update Your Profile</h1>
+  <% cancel_link = root_path %>
   <% form = 'form' %>
 <% else %>
   <h1>Edit User</h1>
   <h2><%= @user %></h2>
+  <% cancel_link = users_path %>
   <% form = 'admin_form' %>
 <% end %>
 
-<%= render :partial => form, :locals => {:button_title => 'Save Changes'} %>
+<%= render :partial => form, :locals => {
+  :button_title => 'Save Changes',
+  :cancel_link => cancel_link } %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,14 +1,16 @@
 <% if signed_in? and current_user.admin? %>
   <h1>New User</h1>
-
+  <% cancel_link = users_path %>
   <% form = 'admin_form' %>
   <% button_title = 'Create' %>
 
 <% else %>
   <h1>Create an Account</h1>
-
+  <% cancel_link = root_path %>
   <% form = 'form' %>
   <% button_title = 'Create Account' %>
 <% end %>
 
-<%= render :partial => form, :locals => {button_title: button_title} %>
+<%= render :partial => form, :locals => {
+  button_title: button_title,
+  cancel_link: cancel_link } %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,10 +9,11 @@ ReviewSite::Application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true
-    Bullet.alert = true
 
     # Detect eager-loaded associations which are not used
     Bullet.unused_eager_loading_enable = false
+
+    Bullet.alert = true
   end
 
   # Settings specified here will take precedence over those in config/application.rb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,9 @@ ReviewSite::Application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.alert = true
+
+    # Detect eager-loaded associations which are not used
+    Bullet.unused_eager_loading_enable = false
   end
 
   # Settings specified here will take precedence over those in config/application.rb

--- a/spec/requests/home_page_spec.rb
+++ b/spec/requests/home_page_spec.rb
@@ -59,7 +59,7 @@ describe "Home page" do
       it { should_not have_selector("a", text: "Show") }
 
       it "links to reviewer invitation page" do
-        click_link 'Ask for Feedback'
+        find("a[href*='/invitations/new']").click
         current_path.should == new_review_invitation_path(@upcoming_review)
       end
 

--- a/spec/requests/review_pages_spec.rb
+++ b/spec/requests/review_pages_spec.rb
@@ -264,7 +264,7 @@ describe "Review pages" do
       # end
 
       it "links to invite reviewer" do
-        click_link "Ask for Feedback"
+        find("a[href*='/invitations/new']").click
         current_path.should == new_review_invitation_path(review)
       end
 


### PR DESCRIPTION
- When looking at a Review, the entire sidenav elements are now clickable, whereas before, you had to click on the text inside the list item
- Badge notification is not the jarring red anymore :)
- Bullet gem no longer creates pop-ups for the "unused eager loading" situation. It will still pop up for the N+1 queries, which should still be addressed as they occur. (i.e. there aren't any pop-ups we should ignore anymore.... we have to pay attention to all of them)
- re: #76, took out the ability to put in a custom subject (want the standard Review Site marker so people know where it's coming from)
- re: #80, changed the cancel button on the (new/edit) Users form to behave differently depending on who is logged in. For admins, it redirects to the /users page, everyone else gets redirected to the home page. 