### PR TITLE
[Max/Louie] defaulting to okta name when can't retrieve full name to avo...

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -45,7 +45,7 @@ module SessionsHelper
     if ENV["OKTA-TEST-MODE"]
       session[:temp_okta_user] || session[:userinfo].split("@")[0]
     else
-      session[:user_name]
+      session[:user_name] || session[:userinfo].split("@")[0]
     end
   end
 


### PR DESCRIPTION
As discussed with Valerie, quick fix to default to okta name when we don't get the user's name back in the OAuth Info from Okta. Hoping that this unblocks people trying to write feedback while we investigate why we're not getting the full name back from Okta.