### PR TITLE
Updating admin permissions around feedback & invitations (#5, #56, and #100)

### DIFF
--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -76,42 +76,6 @@ class FeedbacksController < ApplicationController
     end
   end
 
-  # PUT /feedbacks/1/submit
-  # PUT /feedbacks/1.json
-  def submit
-    respond_to do |format|
-      if @feedback.save
-        @feedback.submit_final
-        format.html {
-          flash[:success] = 'Feedback was successfully updated.'
-          redirect_to root_path
-        }
-        format.json { head :no_content }
-      else
-        format.html { render action: "edit" }
-        format.json { render json: @feedback.errors, status: :unprocessable_entity }
-      end
-    end
-  end
-
-  # PUT /feedbacks/1/unsubmit
-  # PUT /feedbacks/1.json
-  def unsubmit
-    @feedback.submitted = false
-    respond_to do |format|
-      if @feedback.save
-        format.html {
-          flash[:success] = 'Feedback was successfully updated.'
-          redirect_to root_path
-        }
-        format.json { head :no_content }
-      else
-        format.html { render action: "edit" }
-        format.json { render json: @feedback.errors , status: :unprocessable_entity }
-      end
-    end
-  end
-
   # DELETE /feedbacks/1
   # DELETE /feedbacks/1.json
   def destroy

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,8 +46,6 @@ class Ability
         { :user_id => user.id } }
       can :send_reminder, Feedback, :review => { :associate_consultant =>
         { :coach_id => user.id } }
-      cannot :submit, Feedback # only admins can use "submit"/"unsubmit" functions in controller
-      cannot :unsubmit, Feedback
       can :read, Feedback, { :submitted => true, :user_id => user.id }
       can :read, Feedback, { :submitted => true, :review => { :associate_consultant => { :user_id => user.id } } }
       can :read, Feedback, { :submitted => true, :review => { :associate_consultant => { :coach_id => user.id } } }

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -68,18 +68,10 @@ class Ability
         can :manage, ReviewingGroup
         can :manage, AssociateConsultant
         can :manage, User
-        can :manage, Invitation do |invitation|
+        can :read, Invitation do |invitation|
           invitation.review.upcoming?
         end
         can [:summary, :index, :read], Feedback, { submitted: true }
-        can :send_reminder, Feedback, { submitted: false }
-        can :submit, Feedback do |feedback|
-          not feedback.submitted
-        end
-
-        can :unsubmit, Feedback do |feedback|
-          feedback.submitted
-        end
       end
     end
   end

--- a/app/views/feedbacks/_feedbacks.html.erb
+++ b/app/views/feedbacks/_feedbacks.html.erb
@@ -31,7 +31,7 @@
       </td>
       <td class="nowrap button-col">
         <ul>
-          <% if (not feedback.submitted?) and (not feedback.is_additional) %>
+          <% if (not feedback.submitted?) and (not feedback.is_additional) and (can? :send_reminder, feedback) %>
             <li>
               <%= link_to '',
                 send_reminder_review_feedback_path(feedback.review, feedback),
@@ -70,6 +70,7 @@
       <td class="nowrap"><span class="fa fa-lock fa-fw fa-hidden"></span> Not Started</td>
       <td class="nowrap button-col">
         <ul>
+          <% if can? :send_reminder, invitation %>
           <li>
             <%= link_to '',
               send_reminder_review_invitation_path(invitation.review, invitation),
@@ -78,6 +79,8 @@
               title: "Send reminder"
             %>
           </li>
+          <% end %>
+          <% if can? :destroy, invitation %>
           <li>
             <%= link_to '',
               review_invitation_path(invitation.review, invitation),
@@ -86,6 +89,7 @@
               title: "Delete"
             %>
           </li>
+          <% end %>
         </ul>
       </td>
     </tr>

--- a/app/views/feedbacks/_feedbacks.html.erb
+++ b/app/views/feedbacks/_feedbacks.html.erb
@@ -44,11 +44,6 @@
               %>
             </li>
           <% end %>
-          <%  if can? :submit, feedback %>
-            <li> <%= link_to '', submit_review_feedback_path(feedback.review, feedback), method: :put, class: "fa fa-lock fa-lg fa-fw", title: "Submit" %></li>
-              <% elsif can? :unsubmit, feedback %>
-            <li> <%= link_to '', unsubmit_review_feedback_path(feedback.review, feedback), method: :put, class: "fa fa-unlock fa-lg fa-fw", title: "Unsubmit" %></li>
-          <% end %>
           <% if can? :edit, feedback %>
             <li> <%= link_to '', edit_review_feedback_path(feedback.review, feedback), id:"feedback_#{feedback.id}_edit", class: "fa fa-pencil fa-lg fa-fw", title: "Edit" %></li>
           <% end %>

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -135,45 +135,6 @@ describe FeedbacksController do
     end
   end
 
-  describe "PUT unsubmit" do
-    before(:each) do
-      @feedback = FactoryGirl.create(:submitted_feedback)
-      @admin = FactoryGirl.create(:admin_user)
-      set_current_user @admin
-    end
-
-    it "can change the feedback to unsubmited" do
-      @feedback.submitted.should == true
-      put :unsubmit, {:id => @feedback.to_param, :review_id => @feedback.review.id}, valid_session
-      response.should redirect_to(root_url)
-      @feedback.reload
-      @feedback.submitted.should == false
-    end
-  end
-
-  describe "PUT submit" do
-    before(:each) do
-      @feedback = FactoryGirl.create(:feedback)
-      @admin = FactoryGirl.create(:admin_user)
-      set_current_user @admin
-    end
-
-    it "can change the feedback to submited" do
-      @feedback.submitted.should == false
-      put :submit, {:id => @feedback.to_param, :review_id => @feedback.review.id}, valid_session
-      response.should redirect_to(root_url)
-      @feedback.reload
-      @feedback.submitted.should == true
-    end
-
-    it "sends a notification email" do
-      UserMailer.should_receive(:new_feedback_notification
-      ).and_return(double(deliver: true))
-      UserMailer.should_receive(:new_feedback_notification_coach).and_return(double(deliver: true))
-      put :submit, {:id => @feedback.to_param, :review_id => @feedback.review.id}, valid_session
-    end
-  end
-
   describe "PUT update" do
     describe "with valid params" do
       it "updates the requested feedback" do

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -1,10 +1,11 @@
 require 'spec_helper'
 
 describe InvitationsController do
-  let (:admin) { FactoryGirl.create(:admin_user) }
-  let (:review) { FactoryGirl.create(:review, feedback_deadline: Date.today) }
+  let (:user) { FactoryGirl.create(:user) }
+  let (:associate_consultant) { FactoryGirl.create(:associate_consultant, user: user)}
+  let (:review) { FactoryGirl.create(:review, feedback_deadline: Date.today, associate_consultant: associate_consultant) }
 
-  before { set_current_user admin }
+  before { set_current_user user }
 
   def valid_sessions
     {userinfo: "test@test.com"}
@@ -166,7 +167,7 @@ describe InvitationsController do
       set_current_user reviewer
       delete :destroy, {id: invitation.to_param, review_id: review.id}, valid_sessions
       flash[:success].should == "You have successfully declined #{review.associate_consultant.user}\'s feedback request."
-      set_current_user admin
+      set_current_user user
     end
 
     it "send a notification email when reviewee deletes invitation" do
@@ -179,7 +180,7 @@ describe InvitationsController do
 
       delete :destroy, {id: invitation.to_param, review_id: review.id}, valid_sessions
 
-      set_current_user admin
+      set_current_user user
     end
 
     it "otherwise does not send notification email" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -34,31 +34,30 @@ describe Ability do
         should_not be_able_to(:destroy, feedback)
       end
 
-      it "should be able to submit unsubmitted feedback" do
-        should be_able_to(:submit, feedback)
+      it "should not be able to submit or unsubmit unsubmitted feedback" do
+        should_not be_able_to(:submit, feedback)
         should_not be_able_to(:unsubmit, feedback)
       end
 
-      it "should be able to unsubmit submitted feedback" do
+      it "should not be able to unsubmit or submit submitted feedback" do
         feedback.submitted = true
-        should be_able_to(:unsubmit, feedback)
+        should_not be_able_to(:unsubmit, feedback)
         should_not be_able_to(:submit, feedback)
       end
 
-      it "should be able to send reminders on feedback" do
-        should be_able_to(:send_reminder, feedback)
-      end
-
-      it "should not be able to send reminders on submitted feedback" do
+      it "should not be able to send reminders on feedback" do
+        should_not be_able_to(:send_reminder, feedback)
         feedback.submitted = true
         should_not be_able_to(:send_reminder, feedback)
       end
+
     end
 
     describe "dealing with Invitation" do
-      it { should be_able_to(:create, invitation) }
-      it { should be_able_to(:send_reminder, invitation) }
-      it { should be_able_to(:destroy, invitation) }
+      it { should_not be_able_to(:create, invitation) }
+      it { should_not be_able_to(:send_reminder, invitation) }
+      it { should_not be_able_to(:destroy, invitation) }
+      it { should be_able_to(:read, invitation) }
     end
 
     describe "dealing with Review" do

--- a/spec/requests/invitation_pages_spec.rb
+++ b/spec/requests/invitation_pages_spec.rb
@@ -12,34 +12,6 @@ describe "Invitations" do
 
   describe "invitation form" do
 
-    context "as admin" do
-      before do
-        sign_in admin
-        visit new_review_invitation_path(review)
-        fill_in "emails", with: "reviewer@thoughtworks.com"
-        fill_in "message", with: "Why, hello!"
-      end
-
-      it "redirects to review after submission" do
-        click_button "Send"
-        current_path.should == review_path(review)
-        page.should have_selector('.flash-success', text: "An invitation has been sent to: reviewer@thoughtworks.com")
-      end
-
-      it "sends an invitation email" do
-        UserMailer.should_receive(:review_invitation).and_return(double(deliver: true))
-        click_button "Send"
-      end
-
-      it "does not send an email if the 'No email' option is selected" do
-        UserMailer.should_not_receive(:review_invitation)
-        check "no_email"
-        click_button "Send"
-        current_path.should == review_path(review)
-        page.should have_selector('.flash-success', text: "An invitation has been created for: reviewer@thoughtworks.com")
-      end
-    end
-
     context "as ac" do
       before do
         sign_in ac_user

--- a/spec/requests/review_pages_spec.rb
+++ b/spec/requests/review_pages_spec.rb
@@ -257,22 +257,6 @@ describe "Review pages" do
         current_path.should == review_feedback_path(review, feedback)
       end
 
-      # it "links to edit feedback" do
-      #   click_link "feedback_#{feedback.id}_edit"
-      #   current_path.should == edit_review_feedback_path(review, feedback)
-      # end
-
-      it "links to invite reviewer" do
-        find("a[href*='/invitations/new']").click
-        current_path.should == new_review_invitation_path(review)
-      end
-
-   #   it "links to new feedback" do
-   #     click_link "New Feedback"
-#  #     current_path.should == new_review_feedback_path(review)
-   #     current_path.should == root_path
-   #   end
-
       it "links to view summary" do
         click_link "Feedback Summary"
         current_path.should == summary_review_path(review)
@@ -319,9 +303,9 @@ describe "Review pages" do
   describe "delete invitation" do
     let!(:invite) { FactoryGirl.create(:invitation, review: review) }
 
-    describe "as an admin" do
+    describe "as an AC" do
       before do
-        sign_in admin
+        sign_in ac_user
         visit review_path(review)
       end
 


### PR DESCRIPTION
stories 5, 56, and 100 all touch on admin abilities, and since resolving 100 also took as half way to resolving 5 we just collapsed them in. Grand total of 4 new lines of application code, just toggling the presentation of the reminder and destroy buttons in the presentation layer. Mostly needed to update tests that were asserting on the old behaviour. 