### PR TITLE
(Partial?) Fix for feedback requests badge

### DIFF
--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -4,7 +4,7 @@ module FeedbacksHelper
   end
 
   def open_requests(user)
-    invitations = Invitation.eager_load(:feedbacks).where(email: user.all_emails).select {|i| i.feedbacks.compact.empty? }
+    invitations = Invitation.eager_load(:feedbacks).where(email: user.all_emails).select {|i| i.feedbacks.where(user_id: user).compact.empty? }
     user.feedbacks.unsubmitted.size + invitations.size
   end
 end

--- a/spec/helpers/feedbacks_helper_spec.rb
+++ b/spec/helpers/feedbacks_helper_spec.rb
@@ -20,6 +20,12 @@ describe FeedbacksHelper do
         create(:submitted_feedback, user: user, review: invitations.first.review)
         klass.open_requests(user).should == 4
       end
+
+      it 'should include invitations for reviews that have other feedback' do
+        other_user = create(:user)
+        create(:feedback, user: other_user, review: invitations.first.review)
+        klass.open_requests(user).should == 5
+      end
     end
 
     describe 'no invitations' do


### PR DESCRIPTION
Code was not counting invitations if any feedback existed for the review rather than checking that the feedback belonged to the user in question.